### PR TITLE
Add support for 'max' and 'min' in integers, long and real

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Notes about xlsx2yaml
   then also the ntsObjectId field is added
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" field is added if type
-  is not boolean and there is no predefined values to choose from.
+  is not boolean or integer and there is no predefined values to choose from.
   Enable using the -e flag
 * Typical usage:
   * Output to rsmp_schema: No extra options needed
@@ -133,50 +133,53 @@ Aggregated status
 
 Alarms
 
-| Cell  	| Name in Excel          	| YAML                   	| extended? 	|
-|-------	|------------------------	|------------------------	|-----------	|
-| A7..  	| ObjectType             	| [ObjectType]           	|           	|
-| B7..  	| Object (optional)      	| [Object]               	| yes       	|
-| C7..  	| alarmCodeId            	| [alarmCodeId]          	|           	|
-| D7..  	| Description            	| description            	|           	|
-| E7..  	| externalAlarmCodeId    	| externalAlarmCodeId    	| yes       	|
-| F7..  	| externalNtsAlarmCodeId 	| externalNtsAlarmCodeId 	| yes       	|
-| G7..  	| Priority               	| priority               	|           	|
-| H7..  	| Category               	| category               	|           	|
-| I7..  	| Name                   	| [Name]                 	|           	|
-| J7..  	| Type                   	| type                   	|           	|
-| K7..  	| Value                  	| values (list)          	|           	|
-| K7..  	| Value                  	| range (if not boolean) 	| yes       	|
-| L7..  	| Comment                	| description            	|           	|
+| Cell  	| Name in Excel          	| YAML                   		| extended? 	|
+|-------	|------------------------	|------------------------		|-----------	|
+| A7..  	| ObjectType             	| [ObjectType]           		|           	|
+| B7..  	| Object (optional)      	| [Object]               		| yes       	|
+| C7..  	| alarmCodeId            	| [alarmCodeId]          		|           	|
+| D7..  	| Description            	| description            		|           	|
+| E7..  	| externalAlarmCodeId    	| externalAlarmCodeId    		| yes       	|
+| F7..  	| externalNtsAlarmCodeId 	| externalNtsAlarmCodeId 		| yes       	|
+| G7..  	| Priority               	| priority               		|           	|
+| H7..  	| Category               	| category               		|           	|
+| I7..  	| Name                   	| [Name]				|           	|
+| J7..  	| Type                   	| type					|           	|
+| K7..  	| Value                  	| values (list)          		|           	|
+| K7..  	| Value                  	| max,min (integer)          		|           	|
+| K7..  	| Value                  	| range (if not boolean or integer)	| yes       	|
+| L7..  	| Comment                	| description            		|           	|
 
 Status
 
-| Cell  	| Name in Excel     	| YAML                   	| extended? 	|
-|-------	|-------------------	|------------------------	|-----------	|
-| A7..  	| ObjectType        	| [ObjectType]           	|           	|
-| B7..  	| Object (optional) 	| [Object]               	| yes       	|
-| C7..  	| statusCodeId      	| [statusCodeId]         	|           	|
-| D7..  	| Description       	| description            	|           	|
-| E7..  	| Name              	| [Name]                 	|           	|
-| F7..  	| Type              	| type                   	|           	|
-| G7..  	| Value             	| values (list)          	|           	|
-| G7..  	| Value             	| range (if not boolean) 	| yes       	|
-| H7..  	| Comment           	| description            	|           	|
+| Cell  	| Name in Excel     	| YAML                   		| extended? 	|
+|-------	|-------------------	|------------------------		|-----------	|
+| A7..  	| ObjectType        	| [ObjectType]           		|           	|
+| B7..  	| Object (optional) 	| [Object]               		| yes       	|
+| C7..  	| statusCodeId      	| [statusCodeId]         		|           	|
+| D7..  	| Description       	| description            		|           	|
+| E7..  	| Name              	| [Name]                 		|           	|
+| F7..  	| Type              	| type                   		|           	|
+| G7..  	| Value             	| values (list)          		|           	|
+| G7..  	| Value             	| max,min (integer)          		|           	|
+| G7..  	| Value             	| range (if not boolean or integer) 	| yes       	|
+| H7..  	| Comment           	| description            		|           	|
 
 Commands
 
-| Cell  	| Name in Excel     	| YAML                   	| extended? 	|
-|-------	|-------------------	|------------------------	|-----------	|
-| A7..  	| ObjectType        	| [ObjectType]           	|           	|
-| B7..  	| Object (optional) 	| [Object]               	| yes       	|
-| C7..  	| commandCodeId     	| [commandCodeId]        	|           	|
-| D7..  	| Description       	| description            	|           	|
-| E7..  	| Name              	| [Name]                 	|           	|
-| F7..  	| Command           	| command                	|           	|
-| G7..  	| Type              	| type                   	|           	|
-| H7..  	| Value             	| values (list)          	|           	|
-| H7..  	| Value             	| range (if not boolean) 	| yes       	|
-| I7..  	| Comment           	| description            	|           	|
+| Cell  	| Name in Excel     	| YAML                   		| extended? 	|
+|-------	|-------------------	|------------------------		|-----------	|
+| A7..  	| ObjectType        	| [ObjectType]           		|           	|
+| B7..  	| Object (optional) 	| [Object]               		| yes       	|
+| C7..  	| commandCodeId     	| [commandCodeId]        		|           	|
+| D7..  	| Description       	| description            		|           	|
+| E7..  	| Name              	| [Name]                 		|           	|
+| F7..  	| Command           	| command                		|           	|
+| G7..  	| Type              	| type                   		|           	|
+| H7..  	| Value             	| values (list)          		|           	|
+| h7..  	| Value             	| max,min (integer)          		|           	|
+| H7..  	| Value             	| range (if not boolean or integer) 	| yes       	|
+| I7..  	| Comment           	| description            		|           	|
 
 Example usages
 --------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Notes about xlsx2yaml
   then also the ntsObjectId field is added
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" field is added if type
-  is not boolean or integer and there is no predefined values to choose from.
+  is not boolean, integer, long or real and there is no predefined values to choose from.
   Enable using the -e flag
 * Typical usage:
   * Output to rsmp_schema: No extra options needed
@@ -146,8 +146,8 @@ Alarms
 | I7..  	| Name                   	| [Name]				|           	|
 | J7..  	| Type                   	| type					|           	|
 | K7..  	| Value                  	| values (list)          		|           	|
-| K7..  	| Value                  	| max,min (integer)          		|           	|
-| K7..  	| Value                  	| range (if not boolean or integer)	| yes       	|
+| K7..  	| Value                  	| max,min (integer, long, real)		|           	|
+| K7..  	| Value                  	| range (unless using values,min,max)	| yes       	|
 | L7..  	| Comment                	| description            		|           	|
 
 Status
@@ -161,8 +161,8 @@ Status
 | E7..  	| Name              	| [Name]                 		|           	|
 | F7..  	| Type              	| type                   		|           	|
 | G7..  	| Value             	| values (list)          		|           	|
-| G7..  	| Value             	| max,min (integer)          		|           	|
-| G7..  	| Value             	| range (if not boolean or integer) 	| yes       	|
+| G7..  	| Value             	| max,min (integer, long, real)		|           	|
+| G7..  	| Value             	| range (unless using values,min,max) 	| yes       	|
 | H7..  	| Comment           	| description            		|           	|
 
 Commands
@@ -177,8 +177,8 @@ Commands
 | F7..  	| Command           	| command                		|           	|
 | G7..  	| Type              	| type                   		|           	|
 | H7..  	| Value             	| values (list)          		|           	|
-| h7..  	| Value             	| max,min (integer)          		|           	|
-| H7..  	| Value             	| range (if not boolean or integer) 	| yes       	|
+| h7..  	| Value             	| max,min (integer, long, real) 	|           	|
+| H7..  	| Value             	| range (unless using values,min,max)	| yes       	|
 | I7..  	| Comment           	| description            		|           	|
 
 Example usages

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -238,6 +238,13 @@ workbook.each do |sheet|
               end
             }
           else
+            # Set 'max' and 'min' if type is integer
+            if rv[sheet[y][x].value]['type'] == 'integer'
+              values = sheet[y][x+2].value.split("-")
+              rv[sheet[y][x].value]['min'] == values[0]
+              rv[sheet[y][x].value]['max'] == values[1]
+            end
+
             if options[:extended]
               rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
@@ -361,6 +368,13 @@ workbook.each do |sheet|
               end
             }
           else
+            # Set 'max' and 'min' if type is integer
+            if rv[sheet[y][x].value]['type'] == 'integer'
+              values = sheet[y][x+2].value.split("-")
+              rv[sheet[y][x].value]['min'] == values[0]
+              rv[sheet[y][x].value]['max'] == values[1]
+            end
+
             if options[:extended]
               a[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
@@ -438,6 +452,13 @@ workbook.each do |sheet|
                 end
               }
             else
+              # Set 'max' and 'min' if type is integer
+              if rv[sheet[y][x].value]['type'] == 'integer'
+                values = sheet[y][x+3].value.split("-")
+                rv[sheet[y][x].value]['min'] == values[0]
+                rv[sheet[y][x].value]['max'] == values[1]
+              end
+
               if options[:extended]
                 a[sheet[y][x].value]['range'] = sheet[y][x+3].value
               end

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -243,10 +243,10 @@ workbook.each do |sheet|
               values = sheet[y][x+2].value.tr('[]','').split("-")
               rv[sheet[y][x].value]['min'] = values[0].to_i
               rv[sheet[y][x].value]['max'] = values[1].to_i
-            end
-
-            if options[:extended]
-              rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
+            else
+              if options[:extended]
+                rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
+              end
             end
           end
         end
@@ -373,10 +373,10 @@ workbook.each do |sheet|
               values = sheet[y][x+2].value.tr('[]','').split("-")
               a[sheet[y][x].value]['min'] = values[0].to_i
               a[sheet[y][x].value]['max'] = values[1].to_i
-            end
-
-            if options[:extended]
-              a[sheet[y][x].value]['range'] = sheet[y][x+2].value
+            else
+              if options[:extended]
+                a[sheet[y][x].value]['range'] = sheet[y][x+2].value
+              end
             end
           end
         end
@@ -457,10 +457,10 @@ workbook.each do |sheet|
                 values = sheet[y][x+3].value.tr('[]','').split("-")
                 a[sheet[y][x].value]['min'] = values[0].to_i
                 a[sheet[y][x].value]['max'] = values[1].to_i
-              end
-
-              if options[:extended]
-                a[sheet[y][x].value]['range'] = sheet[y][x+3].value
+              else
+                if options[:extended]
+                  a[sheet[y][x].value]['range'] = sheet[y][x+3].value
+                end
               end
             end
           end

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -243,6 +243,7 @@ workbook.each do |sheet|
               values = sheet[y][x+2].value.tr('[]','').split("-")
               rv[sheet[y][x].value]['min'] = values[0].to_i
               rv[sheet[y][x].value]['max'] = values[1].to_i
+              rv[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
             else
               if options[:extended]
                 rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
@@ -373,6 +374,7 @@ workbook.each do |sheet|
               values = sheet[y][x+2].value.tr('[]','').split("-")
               a[sheet[y][x].value]['min'] = values[0].to_i
               a[sheet[y][x].value]['max'] = values[1].to_i
+              a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
             else
               if options[:extended]
                 a[sheet[y][x].value]['range'] = sheet[y][x+2].value
@@ -457,6 +459,7 @@ workbook.each do |sheet|
                 values = sheet[y][x+3].value.tr('[]','').split("-")
                 a[sheet[y][x].value]['min'] = values[0].to_i
                 a[sheet[y][x].value]['max'] = values[1].to_i
+                a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
               else
                 if options[:extended]
                   a[sheet[y][x].value]['range'] = sheet[y][x+3].value

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -338,7 +338,7 @@ workbook.each do |sheet|
       while(sheet[y][x] != nil and sheet[y][x].value != nil and !sheet[y][x].value.empty?) do
         a[sheet[y][x].value] = {
             'type' => sheet[y][x+1].value,
-             'description' => sheet[y][x+3].value
+             'description' => sheet[y][x+3].value.chomp
         }
 
         # No need to output values if type is boolean

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -240,9 +240,9 @@ workbook.each do |sheet|
           else
             # Set 'max' and 'min' if type is integer
             if rv[sheet[y][x].value]['type'] == 'integer'
-              values = sheet[y][x+2].value.split("-")
-              rv[sheet[y][x].value]['min'] == values[0]
-              rv[sheet[y][x].value]['max'] == values[1]
+              values = sheet[y][x+2].value.tr('[]','').split("-")
+              rv[sheet[y][x].value]['min'] = values[0].to_i
+              rv[sheet[y][x].value]['max'] = values[1].to_i
             end
 
             if options[:extended]
@@ -369,10 +369,10 @@ workbook.each do |sheet|
             }
           else
             # Set 'max' and 'min' if type is integer
-            if rv[sheet[y][x].value]['type'] == 'integer'
-              values = sheet[y][x+2].value.split("-")
-              rv[sheet[y][x].value]['min'] == values[0]
-              rv[sheet[y][x].value]['max'] == values[1]
+            if a[sheet[y][x].value]['type'] == 'integer'
+              values = sheet[y][x+2].value.tr('[]','').split("-")
+              a[sheet[y][x].value]['min'] = values[0].to_i
+              a[sheet[y][x].value]['max'] = values[1].to_i
             end
 
             if options[:extended]
@@ -453,10 +453,10 @@ workbook.each do |sheet|
               }
             else
               # Set 'max' and 'min' if type is integer
-              if rv[sheet[y][x].value]['type'] == 'integer'
-                values = sheet[y][x+3].value.split("-")
-                rv[sheet[y][x].value]['min'] == values[0]
-                rv[sheet[y][x].value]['max'] == values[1]
+              if a[sheet[y][x].value]['type'] == 'integer'
+                values = sheet[y][x+3].value.tr('[]','').split("-")
+                a[sheet[y][x].value]['min'] = values[0].to_i
+                a[sheet[y][x].value]['max'] = values[1].to_i
               end
 
               if options[:extended]

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -238,8 +238,8 @@ workbook.each do |sheet|
               end
             }
           else
-            # Set 'max' and 'min' if type is integer
-            if rv[sheet[y][x].value]['type'] == 'integer'
+            # Set 'max' and 'min' if type is integer, long or real
+            if rv[sheet[y][x].value]['type'] == 'integer' or rv[sheet[y][x].value]['type'] == 'long' or rv[sheet[y][x].value]['type'] == 'real'
               values = sheet[y][x+2].value.tr('[]','').split("-")
               rv[sheet[y][x].value]['min'] = values[0].to_i
               rv[sheet[y][x].value]['max'] = values[1].to_i
@@ -368,8 +368,8 @@ workbook.each do |sheet|
               end
             }
           else
-            # Set 'max' and 'min' if type is integer
-            if a[sheet[y][x].value]['type'] == 'integer'
+            # Set 'max' and 'min' if type is integer, long or real
+            if a[sheet[y][x].value]['type'] == 'integer' or a[sheet[y][x].value]['type'] == 'long' or a[sheet[y][x].value]['type'] == 'real'
               values = sheet[y][x+2].value.tr('[]','').split("-")
               a[sheet[y][x].value]['min'] = values[0].to_i
               a[sheet[y][x].value]['max'] = values[1].to_i
@@ -452,8 +452,8 @@ workbook.each do |sheet|
                 end
               }
             else
-              # Set 'max' and 'min' if type is integer
-              if a[sheet[y][x].value]['type'] == 'integer'
+              # Set 'max' and 'min' if type is integer, long or real
+              if a[sheet[y][x].value]['type'] == 'integer' or a[sheet[y][x].value]['type'] == 'long' or a[sheet[y][x].value]['type'] == 'real'
                 values = sheet[y][x+3].value.tr('[]','').split("-")
                 a[sheet[y][x].value]['min'] = values[0].to_i
                 a[sheet[y][x].value]['max'] = values[1].to_i

--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -185,7 +185,7 @@ def print_alarms():
                     if "arguments" in alarm:
                         for argument_name, argument in alarm['arguments'].items():
                             name = argument_name
-                            type = argument['type']
+                            type = argument['type'].replace("_list", "")
 
                             # If the 'values' exists, use it to construct a list
                             if "values" in argument:
@@ -295,7 +295,8 @@ def print_status():
                     if "arguments" in status:
                         for argument_name,argument in status['arguments'].items():
                             name = argument_name
-                            type = argument['type']
+                            type = argument['type'].replace("_list", "")
+
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:
@@ -391,7 +392,9 @@ def print_commands():
                     if "arguments" in command:
                         for argument_name,argument in command['arguments'].items():
                             name = argument_name
-                            type = argument['type']
+                            type = argument['type'].replace("_list", "")
+
+                            # If the 'values' exists, use it to construct a list
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:

--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -186,6 +186,8 @@ def print_alarms():
                         for argument_name, argument in alarm['arguments'].items():
                             name = argument_name
                             type = argument['type']
+
+                            # If the 'values' exists, use it to construct a list
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:
@@ -193,22 +195,22 @@ def print_alarms():
                                 value = " |br| ".join(val_list)
 
                             else:
-                                # Extended
-                                if "range" in argument:
-                                    value = argument['range']
-                                else:
-                                    if type == "boolean":
-                                        value = "-True |br| -False"
-                                    elif type == "integer":
-                                      if "min" in argument:
+                                if type == "boolean":
+                                    value = "-True |br| -False"
+                                elif type == "integer" or type == "long" or type == "float":
+                                    if "min" in argument:
                                         min = argument['min']
-                                      else:
+                                    else:
                                         min = ""
-                                      if "max" in argument:
+                                    if "max" in argument:
                                         max = argument['max']
-                                      else:
+                                    else:
                                         max = ""
-                                      value = "[" + str(min) + "-" + str(max) + "]"
+                                    value = "[" + str(min) + "-" + str(max) + "]"
+                                else:
+                                    # Extended
+                                    if "range" in argument:
+                                        value = argument['range']
                                     else:
                                         value = ""
                             if "description" in argument:
@@ -300,22 +302,22 @@ def print_status():
                                     val_list.append("-" + str(v))
                                 value = " |br| ".join(val_list)
                             else:
-                                # Extended
-                                if "range" in argument:
-                                    value = argument['range']
-                                else:
-                                    if type == "boolean":
-                                        value = "-False |br| -True"
-                                    elif type == "integer":
-                                      if "min" in argument:
+                                if type == "boolean":
+                                    value = "-False |br| -True"
+                                elif type == "integer" or type == "long" or type == "float":
+                                    if "min" in argument:
                                         min = argument['min']
-                                      else:
+                                    else:
                                         min = ""
-                                      if "max" in argument:
+                                    if "max" in argument:
                                         max = argument['max']
-                                      else:
+                                    else:
                                         max = ""
-                                      value = "[" + str(min) + "-" + str(max) + "]"
+                                    value = "[" + str(min) + "-" + str(max) + "]"
+                                else:
+                                    # Extended
+                                    if "range" in argument:
+                                        value = argument['range']
                                     else:
                                         value = ""
                             if "description" in argument:
@@ -396,22 +398,22 @@ def print_commands():
                                     val_list.append("-" + v)
                                 value = " |br| ".join(val_list)
                             else:
-                                # Extended
-                                if "range" in argument:
-                                    value = argument['range']
-                                else:
-                                    if(type == "boolean"):
-                                        value = "-False |br| -True"
-                                    elif type == "integer":
-                                      if "min" in argument:
+                                if(type == "boolean"):
+                                    value = "-False |br| -True"
+                                elif type == "integer":
+                                    if "min" in argument:
                                         min = argument['min']
-                                      else:
+                                    else:
                                         min = ""
-                                      if "max" in argument:
+                                    if "max" in argument:
                                         max = argument['max']
-                                      else:
+                                    else:
                                         max = ""
-                                      value = "[" + str(min) + "-" + str(max) + "]"
+                                    value = "[" + str(min) + "-" + str(max) + "]"
+                                else:
+                                    # Extended
+                                    if "range" in argument:
+                                        value = argument['range']
                                     else:
                                         value = ""
                             if "description" in argument:

--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -197,8 +197,18 @@ def print_alarms():
                                 if "range" in argument:
                                     value = argument['range']
                                 else:
-                                    if(type == "boolean"):
+                                    if type == "boolean":
                                         value = "-True |br| -False"
+                                    elif type == "integer":
+                                      if "min" in argument:
+                                        min = argument['min']
+                                      else:
+                                        min = ""
+                                      if "max" in argument:
+                                        max = argument['max']
+                                      else:
+                                        max = ""
+                                      value = "[" + str(min) + "-" + str(max) + "]"
                                     else:
                                         value = ""
                             if "description" in argument:
@@ -294,8 +304,18 @@ def print_status():
                                 if "range" in argument:
                                     value = argument['range']
                                 else:
-                                    if(type == "boolean"):
+                                    if type == "boolean":
                                         value = "-False |br| -True"
+                                    elif type == "integer":
+                                      if "min" in argument:
+                                        min = argument['min']
+                                      else:
+                                        min = ""
+                                      if "max" in argument:
+                                        max = argument['max']
+                                      else:
+                                        max = ""
+                                      value = "[" + str(min) + "-" + str(max) + "]"
                                     else:
                                         value = ""
                             if "description" in argument:
@@ -382,6 +402,16 @@ def print_commands():
                                 else:
                                     if(type == "boolean"):
                                         value = "-False |br| -True"
+                                    elif type == "integer":
+                                      if "min" in argument:
+                                        min = argument['min']
+                                      else:
+                                        min = ""
+                                      if "max" in argument:
+                                        max = argument['max']
+                                      else:
+                                        max = ""
+                                      value = "[" + str(min) + "-" + str(max) + "]"
                                     else:
                                         value = ""
                             if "description" in argument:

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -199,15 +199,21 @@ sxl["objects"].each { |object|
           unless value["range"].nil?
             set_cell(sheet, col+2, row, value["range"])
           else
-            # Make a list of values and append to description
-            values = ""
             description = ""
-            value["values"].each { |v, desc |
-              values += "-" + v + "\n"
-              unless desc.empty?
-                description += + v + ": " + desc + "\n"
-              end
-            }
+            if not value["values"].nil?
+              # Make a list of values and append to description
+              values = ""
+              value["values"].each { |v, desc |
+                values += "-" + v.to_s + "\n"
+                unless desc.empty?
+                  description += + v.to_s + ": " + desc + "\n"
+                end
+              }
+            elsif not value["min"].nil?
+              min = value["min"]
+              max = value["max"]
+              values = "[" + min.to_s + "-" + max.to_s + "]"
+            end
             values.chomp!
             description.chomp!
             if value["description"].nil?
@@ -241,7 +247,7 @@ sxl["objects"].each { |object|
     set_cell(sheet, 2, row, item[1]["object"]) # object
     set_cell(sheet, 3, row, item[0])
     if options[:short].nil?
-      set_cell(sheet, 4, row, item[1]["description"])
+      set_cell(sheet, 4, row, item[1]["description"].chomp)
     else
       set_cell(sheet, 4, row, item[1]["description"].lines.first.chomp)
     end
@@ -259,15 +265,21 @@ sxl["objects"].each { |object|
         unless value["range"].nil?
           set_cell(sheet, col+2, row, value["range"])
         else
-          # Make a list of values and append to description
-          values = ""
           description = ""
-          value["values"].each { |v, desc |
-            values += "-" + v.to_s + "\n"
-            unless desc.empty?
-              description += + v.to_s + ": " + desc + "\n"
-            end
-          }
+          if not value["values"].nil?
+            # Make a list of values and append to description
+            values = ""
+            value["values"].each { |v, desc |
+              values += "-" + v.to_s + "\n"
+              unless desc.empty?
+                description += + v.to_s + ": " + desc + "\n"
+              end
+            }
+          elsif not value["min"].nil?
+            min = value["min"]
+            max = value["max"]
+            values = "[" + min.to_s + "-" + max.to_s + "]"
+          end
           values.chomp!
           description.chomp!
           if value["description"].nil?
@@ -315,15 +327,21 @@ sxl["objects"].each { |object|
         unless value["range"].nil?
           set_cell(sheet, col+3, row, value["range"])
         else
-          # Make a list of values and append to description
-          values = ""
           description = ""
-          value["values"].each { |v, desc |
-            values += "-" + v + "\n"
-            unless desc.empty?
-              description += + v + ": " + desc + "\n"
-            end
-          }
+          if not value["values"].nil?
+            # Make a list of values and append to description
+            values = ""
+            value["values"].each { |v, desc |
+              values += "-" + v.to_s + "\n"
+              unless desc.empty?
+                description += + v.to_s + ": " + desc + "\n"
+              end
+            }
+          elsif not value["min"].nil?
+            min = value["min"]
+            max = value["max"]
+            values = "[" + min.to_s + "-" + max.to_s + "]"
+          end
           values.chomp!
           description.chomp!
           if value["description"].nil?

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -195,6 +195,7 @@ sxl["objects"].each { |object|
             values = "-False\n-True"
             set_cell(sheet, col+2, row, values)
         else
+          # If 'range' exists, just use it
           unless value["range"].nil?
             set_cell(sheet, col+2, row, value["range"])
           else
@@ -254,6 +255,7 @@ sxl["objects"].each { |object|
           values = "-False\n-True"
           set_cell(sheet, col+2, row, values)
       else
+        # If 'range' exists, just use it
         unless value["range"].nil?
           set_cell(sheet, col+2, row, value["range"])
         else
@@ -309,6 +311,7 @@ sxl["objects"].each { |object|
           values = "-False\n-True"
           set_cell(sheet, col+3, row, values)
       else
+        # If 'range' exists, just use it
         unless value["range"].nil?
           set_cell(sheet, col+3, row, value["range"])
         else

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -189,6 +189,9 @@ sxl["objects"].each { |object|
     col = 9
     unless item[1]["arguments"].nil?
       item[1]["arguments"].each { |argument, value|
+        # Remove _list from the type (integer_list)
+        value["type"].gsub!("_list", "")
+
         set_cell(sheet, col, row, argument)
         set_cell(sheet, col+1, row, value["type"])
         if value["type"] == "boolean"
@@ -255,6 +258,9 @@ sxl["objects"].each { |object|
     # Return values
     col = 5
     item[1]["arguments"].each { |argument, value|  # in statuses, it's called return value
+      # Remove _list from the type (integer_list)
+      value["type"].gsub!("_list", "")
+
       set_cell(sheet, col, row, argument)
       set_cell(sheet, col+1, row, value["type"])
       if value["type"] == "boolean"
@@ -316,6 +322,9 @@ sxl["objects"].each { |object|
     # Arguments
     col = 5
     item[1]["arguments"].each { |argument, value|
+      # Remove _list from the type (integer_list)
+      value["type"].gsub!("_list", "")
+
       set_cell(sheet, col, row, argument)
       set_cell(sheet, col+1, row, item[1]["command"])
       set_cell(sheet, col+2, row, value["type"])


### PR DESCRIPTION
Needed for https://github.com/rsmp-nordic/rsmp_sxl_variable_message_sign/pull/1

- [x] xlsx2yaml.rb: Add support for `max` and `min' in integers, long and real
- [x] yaml2xlsx.rb: Add support for `max` and 'min' in integers, long and real
- [x] yaml2rst.py: Add support for `max` and 'min' in integers, long and real
- [x] Update documentation
- [x] Use type `integer_list`

Disable the use of "range" for integers, long and real. They have to either use "values" or "min", "max". This changes the TLC SXL slightly