### PR TITLE
yaml2rst: Use bullet lists inside tables

### DIFF
--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -191,12 +191,12 @@ def print_alarms():
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:
-                                    val_list.append("-" + v)
-                                value = " |br| ".join(val_list)
+                                    val_list.append("* " + v)
+                                value = "\n".join(val_list)
 
                             else:
                                 if type == "boolean":
-                                    value = "-True |br| -False"
+                                    value = "* True\n* False"
                                 elif type == "integer" or type == "long" or type == "float":
                                     if "min" in argument:
                                         min = argument['min']
@@ -300,11 +300,11 @@ def print_status():
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:
-                                    val_list.append("-" + str(v))
-                                value = " |br| ".join(val_list)
+                                    val_list.append("* " + str(v))
+                                value = "\n".join(val_list)
                             else:
                                 if type == "boolean":
-                                    value = "-False |br| -True"
+                                    value = "* False\n* True"
                                 elif type == "integer" or type == "long" or type == "float":
                                     if "min" in argument:
                                         min = argument['min']
@@ -398,11 +398,11 @@ def print_commands():
                             if "values" in argument:
                                 val_list = []
                                 for v in argument['values']:
-                                    val_list.append("-" + v)
-                                value = " |br| ".join(val_list)
+                                    val_list.append("* " + v)
+                                value = "\n".join(val_list)
                             else:
                                 if(type == "boolean"):
-                                    value = "-False |br| -True"
+                                    value = "* False\n* True"
                                 elif type == "integer":
                                     if "min" in argument:
                                         min = argument['min']


### PR DESCRIPTION
Discussed in #14

Bullet lists makes easier tro read RST output, but visual results has some issues.
- [ ] Bullet lists gets wrong formatting in the current HTML theme. Use another theme?
- [ ] Bullet lists looks wrong in the PDF output

Example of PDF output:

<img width="729" alt="Skärmavbild 2021-10-07 kl  11 16 47" src="https://user-images.githubusercontent.com/2820709/136356410-45fcbaad-6427-4917-8245-2e4af2ac68ff.png">

