### PR TITLE
Split sxl and site information in two separate yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Notes about xlsx2yaml
 * Requires: gem install rubyXL
 * Usage: xlsx2yaml [options] [XLSX]
 * -s, --site. Prints [site information](#site). Includes also id, version and date
-* -e, --extended. Prints [extended information](#extended)
 * If using the -s flag in combination with the -e flag,
   then also the ntsObjectId field is added
 * Since the "values" fields in alarms, statuses and commands cannot easily
@@ -47,7 +46,6 @@ Notes about yaml2xlsx
 
 * Requires: gem install rubyXL
 * Needs an excel template
-* Prints [extended information](#extended) if the fields are present
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" fields is also
   supported.
@@ -58,8 +56,7 @@ Notes about yaml2rst
 --------------------
 
 * Requires: pip3 install pyyaml tabulate --user (or apt install python3-tabulate)
-* Prints some of the [extended information](#extended) if they are present
-  They are generated with xlsx2yaml.rb using the -e and -s flags
+* Prints extended fields if they "--extended" option is used.
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" fields is also
   supported. The "range" field can be added using xlsx2yaml using the -e flag
@@ -71,118 +68,97 @@ Site fields contains all the individual components of a specific site. This
 is needed by the RSMP simulator to tie a specific component (object) to an
 alarm, status or command, but is not needed to construct a JSon schema.
 
-<a name="extended"></a>
-Extended information
---------------------
-Extended fields contains all fields of the SXL, not just those needed to
-construct a JSon schema.
-
-List of fields:
-* `constructor` (version)
-* `reviewed` (version)
-* `approved` (version)
-* `created-date` (version)
-* `rsmp-version` (version)
-* `ntsObjectId` (objects) only if site information is enabled
-* `externalNtsId` (objects) only if site information is enabled
-* `range` (alarms, status, commands)
-* `object` (alarms, status, commands) only if site information is enabled
-* `externalAlarmCodeId` (alarms)
-* `externalNtsAlarmCodeId` (alarms)
-* `functional_position` (aggregated status)
-* `functional_state` (aggregated status)
-
 Mapping between XLSX and YAML format of the SXL
 -----------------------------------------------
 Version sheet
 
-| Cell 	| Name in Excel   	| YAML         	| extended? 	|
-|------	|-----------------	|--------------	|-----------	|
-| B2   	| Plant id        	| id           	|           	|
-| B6   	| Plant name      	| description  	|           	|
-| B10  	| Constructor     	| constructor  	| yes       	|
-| B12  	| Reviewed        	| reviewed     	| yes       	|
-| B15  	| Approved        	| approved     	| yes       	|
-| B18  	| Created date    	| created-date 	| yes       	|
-| B21  	| Revision number 	| version      	|           	|
-| C21  	| Revision date   	| date         	|           	|
-| B26  	| RSMP version    	| rsmp-version 	| yes       	|
+| Cell 	| Name in Excel   	| YAML         	|
+|------	|-----------------	|--------------	|
+| B2   	| Plant id        	| id           	|
+| B6   	| Plant name      	| description  	|
+| B10  	| Constructor     	| constructor  	|
+| B12  	| Reviewed        	| reviewed     	|
+| B15  	| Approved        	| approved     	|
+| B18  	| Created date    	| created-date 	|
+| B21  	| Revision number 	| version      	|
+| C21  	| Revision date   	| date         	|
+| B26  	| RSMP version    	| rsmp-version 	|
 
 Object types
 
-| Cell 	| Name in Excel       	| YAML         	| extended? 	|
-|------	|---------------------	|--------------	|-----------	|
-| A7.. 	| ObjectType          	| [ObjectType] 	|           	|
-| B7.. 	| Description/comment 	| description  	| yes       	|
+| Cell 	| Name in Excel       	| YAML         	|
+|------	|---------------------	|--------------	|
+| A7.. 	| ObjectType          	| [ObjectType] 	|
+| B7.. 	| Description/comment 	| description  	|
 
 Objects ([site information](#site))
 
-| Cell 	| Name in Excel 	| YAML                    	| extended? 	|
-|------	|---------------	|-------------------------	|-----------	|
-| A7.. 	| ObjectType    	| [ObjectType]            	|           	|
-| B7.. 	| Object        	| [Object]                	|           	|
-| C7.. 	| componentId   	| [Object]: [componentId] 	|           	|
-| D7.. 	| NTSObjectId   	| ntsObjectid             	| yes       	|
-| E7.. 	| externalNtsId 	| externalNtsId           	| yes       	|
-| F7.. 	| Description   	| description             	| yes       	|
+| Cell 	| Name in Excel 	| YAML                    	|
+|------	|---------------	|-------------------------	|
+| A7.. 	| ObjectType    	| [ObjectType]            	|
+| B7.. 	| Object        	| [Object]                	|
+| C7.. 	| componentId   	| [Object]: [componentId] 	|
+| D7.. 	| NTSObjectId   	| ntsObjectid             	|
+| E7.. 	| externalNtsId 	| externalNtsId           	|
+| F7.. 	| Description   	| description             	|
 
 Aggregated status
 
-| Cell  	| Name in Excel      	| YAML                          | extended? |
-|-------	|--------------------	|-----------------------------  |-----------|
-| C7..  	| functionalPosition 	| functional_position           | yes       |
-| D7..  	| functionalState    	| functional_state              | yes       |
-| A17.. 	| Comment            	| aggregated_status_description | yes       |
+| Cell  	| Name in Excel      	| YAML                          |
+|-------	|--------------------	|-----------------------------  |
+| C7..  	| functionalPosition 	| functional_position           |
+| D7..  	| functionalState    	| functional_state              |
+| A17.. 	| Comment            	| aggregated_status_description |
 
 Alarms
 
-| Cell  	| Name in Excel          	| YAML                   		| extended? 	|
-|-------	|------------------------	|------------------------		|-----------	|
-| A7..  	| ObjectType             	| [ObjectType]           		|           	|
-| B7..  	| Object (optional)      	| [Object]               		| yes       	|
-| C7..  	| alarmCodeId            	| [alarmCodeId]          		|           	|
-| D7..  	| Description            	| description            		|           	|
-| E7..  	| externalAlarmCodeId    	| externalAlarmCodeId    		| yes       	|
-| F7..  	| externalNtsAlarmCodeId 	| externalNtsAlarmCodeId 		| yes       	|
-| G7..  	| Priority               	| priority               		|           	|
-| H7..  	| Category               	| category               		|           	|
-| I7..  	| Name                   	| [Name]				|           	|
-| J7..  	| Type                   	| type					|           	|
-| K7..  	| Value                  	| values (list)          		|           	|
-| K7..  	| Value                  	| max,min (integer, long, real)		|           	|
-| K7..  	| Value                  	| range (unless using values,min,max)	| yes       	|
-| L7..  	| Comment                	| description            		|           	|
+| Cell  	| Name in Excel          	| YAML                   		|
+|-------	|------------------------	|------------------------		|
+| A7..  	| ObjectType             	| [ObjectType]           		|
+| B7..  	| Object (optional)      	| [Object]               		|
+| C7..  	| alarmCodeId            	| [alarmCodeId]          		|
+| D7..  	| Description            	| description            		|
+| E7..  	| externalAlarmCodeId    	| externalAlarmCodeId    		|
+| F7..  	| externalNtsAlarmCodeId 	| externalNtsAlarmCodeId 		|
+| G7..  	| Priority               	| priority               		|
+| H7..  	| Category               	| category               		|
+| I7..  	| Name                   	| [Name]				|
+| J7..  	| Type                   	| type					|
+| K7..  	| Value                  	| values (list)          		|
+| K7..  	| Value                  	| max,min (integer, long, real)		|
+| K7..  	| Value                  	| range (unless using values,min,max)	|
+| L7..  	| Comment                	| description            		|
 
 Status
 
-| Cell  	| Name in Excel     	| YAML                   		| extended? 	|
-|-------	|-------------------	|------------------------		|-----------	|
-| A7..  	| ObjectType        	| [ObjectType]           		|           	|
-| B7..  	| Object (optional) 	| [Object]               		| yes       	|
-| C7..  	| statusCodeId      	| [statusCodeId]         		|           	|
-| D7..  	| Description       	| description            		|           	|
-| E7..  	| Name              	| [Name]                 		|           	|
-| F7..  	| Type              	| type                   		|           	|
-| G7..  	| Value             	| values (list)          		|           	|
-| G7..  	| Value             	| max,min (integer, long, real)		|           	|
-| G7..  	| Value             	| range (unless using values,min,max) 	| yes       	|
-| H7..  	| Comment           	| description            		|           	|
+| Cell  	| Name in Excel     	| YAML                   		|
+|-------	|-------------------	|------------------------		|
+| A7..  	| ObjectType        	| [ObjectType]           		|
+| B7..  	| Object (optional) 	| [Object]               		|
+| C7..  	| statusCodeId      	| [statusCodeId]         		|
+| D7..  	| Description       	| description            		|
+| E7..  	| Name              	| [Name]                 		|
+| F7..  	| Type              	| type                   		|
+| G7..  	| Value             	| values (list)          		|
+| G7..  	| Value             	| max,min (integer, long, real)		|
+| G7..  	| Value             	| range (unless using values,min,max) 	|
+| H7..  	| Comment           	| description            		|
 
 Commands
 
-| Cell  	| Name in Excel     	| YAML                   		| extended? 	|
-|-------	|-------------------	|------------------------		|-----------	|
-| A7..  	| ObjectType        	| [ObjectType]           		|           	|
-| B7..  	| Object (optional) 	| [Object]               		| yes       	|
-| C7..  	| commandCodeId     	| [commandCodeId]        		|           	|
-| D7..  	| Description       	| description            		|           	|
-| E7..  	| Name              	| [Name]                 		|           	|
-| F7..  	| Command           	| command                		|           	|
-| G7..  	| Type              	| type                   		|           	|
-| H7..  	| Value             	| values (list)          		|           	|
-| h7..  	| Value             	| max,min (integer, long, real) 	|           	|
-| H7..  	| Value             	| range (unless using values,min,max)	| yes       	|
-| I7..  	| Comment           	| description            		|           	|
+| Cell  	| Name in Excel     	| YAML                   		|
+|-------	|-------------------	|------------------------		|
+| A7..  	| ObjectType        	| [ObjectType]           		|
+| B7..  	| Object (optional) 	| [Object]               		|
+| C7..  	| commandCodeId     	| [commandCodeId]        		|
+| D7..  	| Description       	| description            		|
+| E7..  	| Name              	| [Name]                 		|
+| F7..  	| Command           	| command                		|
+| G7..  	| Type              	| type                   		|
+| H7..  	| Value             	| values (list)          		|
+| h7..  	| Value             	| max,min (integer, long, real) 	|
+| H7..  	| Value             	| range (unless using values,min,max)	|
+| I7..  	| Comment           	| description            		|
 
 Example usages
 --------------
@@ -193,16 +169,16 @@ Example 1: Convert the SXL from Excel to YAML.
 xlsx2yaml.rb SXL_Traffic_Controller.xlsx
 ```
 
-Example 2: Convert the SXL from Excel format to RST, including extended attributes.
+Example 2: Convert the SXL from Excel format to RST.
 
 ```
-xlsx2yaml.rb -e SXL_Traffic_Controller.xlsx | yaml2rst.py > sxl_traffic_light_controller.rst
+xlsx2yaml.rb SXL_Traffic_Controller.xlsx | yaml2rst.py > sxl_traffic_light_controller.rst
 ```
 
 Example 3: Convert the SXL from Excel format to YAML, and then back again to Excel using a template.
-Includes extended attributes and site information
+Includes site information
 
 ```
-xlsx2yaml.rb -s -e SXL_Traffic_Controller.xlsx | yaml2xlsx.rb --template "RSMP_Template_SignalExchangeList-20120117.xlsx"
+xlsx2yaml.rb -s SXL_Traffic_Controller.xlsx | yaml2xlsx.rb --template "RSMP_Template_SignalExchangeList-20120117.xlsx"
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ various formats.
 
 Notes about create_template.py
 ------------------------------
-* Requires: pip3 install xlsxwriter --user
+* Requires: pip3 install xlsxwriter --user (or apt install python3-xlsxwriter)
 * Usage: create_template.py [OPTIONS]
 * See create_template.py -h for available options
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,13 @@ Notes about xlsx2yaml
 * Requires: gem install rubyXL
 * Usage: xlsx2yaml [options] [XLSX]
 * -s, --site. Prints [site information](#site). Includes also id, version and date
-* If using the -s flag in combination with the -e flag,
-  then also the ntsObjectId field is added
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" field is added if type
   is not boolean, integer, long or real and there is no predefined values to choose from.
-  Enable using the -e flag
 * Typical usage:
   * Output to rsmp_schema: No extra options needed
-  * Output to rst-format for the SXL TLC specification: Use the -e flag (for "value")
-  * Output to yaml-format and back to Excel-format: Use the -e and -s flag
+  * Output to rst-format for the SXL TLC specification: No extra options needed
+  * Output to yaml-format and back to Excel-format: Use -s flag
 
 Notes about yaml2xlsx
 ---------------------
@@ -56,7 +53,7 @@ Notes about yaml2rst
 --------------------
 
 * Requires: pip3 install pyyaml tabulate --user (or apt install python3-tabulate)
-* Prints extended fields if they "--extended" option is used.
+* Prints extended fields if the "--extended" option is used.
 * Since the "values" fields in alarms, statuses and commands cannot easily
   be converted from the SXL in Excel format, the "range" fields is also
   supported. The "range" field can be added using xlsx2yaml using the -e flag

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Notes about xlsx2yaml
 
 * Requires: gem install rubyXL
 * Usage: xlsx2yaml [options] [XLSX]
+* -o, --objects. Print the alarms, status and commands
 * -s, --site. Prints [site information](#site). Includes also id, version and date
 * Typical usage:
   * Output to rsmp_schema: No extra options needed

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Notes about xlsx2yaml
 * Requires: gem install rubyXL
 * Usage: xlsx2yaml [options] [XLSX]
 * -s, --site. Prints [site information](#site). Includes also id, version and date
-* Since the "values" fields in alarms, statuses and commands cannot easily
-  be converted from the SXL in Excel format, the "range" field is added if type
-  is not boolean, integer, long or real and there is no predefined values to choose from.
 * Typical usage:
   * Output to rsmp_schema: No extra options needed
   * Output to rst-format for the SXL TLC specification: No extra options needed
@@ -43,9 +40,6 @@ Notes about yaml2xlsx
 
 * Requires: gem install rubyXL
 * Needs an excel template
-* Since the "values" fields in alarms, statuses and commands cannot easily
-  be converted from the SXL in Excel format, the "range" fields is also
-  supported.
 * The Excel file is written to "output.xlsx"
 
 
@@ -54,9 +48,6 @@ Notes about yaml2rst
 
 * Requires: pip3 install pyyaml tabulate --user (or apt install python3-tabulate)
 * Prints extended fields if the "--extended" option is used.
-* Since the "values" fields in alarms, statuses and commands cannot easily
-  be converted from the SXL in Excel format, the "range" fields is also
-  supported. The "range" field can be added using xlsx2yaml using the -e flag
 
 <a name="site"></a>
 Site information
@@ -123,7 +114,6 @@ Alarms
 | J7..  	| Type                   	| type					|
 | K7..  	| Value                  	| values (list)          		|
 | K7..  	| Value                  	| max,min (integer, long, real)		|
-| K7..  	| Value                  	| range (unless using values,min,max)	|
 | L7..  	| Comment                	| description            		|
 
 Status
@@ -138,7 +128,6 @@ Status
 | F7..  	| Type              	| type                   		|
 | G7..  	| Value             	| values (list)          		|
 | G7..  	| Value             	| max,min (integer, long, real)		|
-| G7..  	| Value             	| range (unless using values,min,max) 	|
 | H7..  	| Comment           	| description            		|
 
 Commands
@@ -154,7 +143,6 @@ Commands
 | G7..  	| Type              	| type                   		|
 | H7..  	| Value             	| values (list)          		|
 | h7..  	| Value             	| max,min (integer, long, real) 	|
-| H7..  	| Value             	| range (unless using values,min,max)	|
 | I7..  	| Comment           	| description            		|
 
 Example usages

--- a/create_template.py
+++ b/create_template.py
@@ -9,6 +9,14 @@ parser.add_argument('--num-grouped-objects', default=15, type=int,
     help='Number of grouped objects')
 parser.add_argument('--num-single-objects', default=29, type=int,
     help='Number of single objects')
+parser.add_argument('--num-alarms', default=26, type=int,
+    help='Number of alarms')
+parser.add_argument('--alarm-rvs', default=26, type=int,
+    help='Number of alarm return values')
+parser.add_argument('--num-statuses', default=52, type=int,
+    help='Number of statuses')
+parser.add_argument('--status-rvs', default=2, type=int,
+    help='Number of status return values')
 parser.add_argument('--num-command-functional-position', default=3, type=int,
     help='Number of commands of type functional position')
 parser.add_argument('--num-command-functional-state', default=3, type=int,
@@ -17,10 +25,6 @@ parser.add_argument('--num-command-maneuver', default=3, type=int,
     help='Number of commands of type maneuver')
 parser.add_argument('--num-command-parameters', default=3, type=int,
     help='Number of commands of type parameter')
-parser.add_argument('--alarm-rvs', default=2, type=int,
-    help='Number of alarm return values')
-parser.add_argument('--status-rvs', default=2, type=int,
-    help='Number of status return values')
 parser.add_argument('--command-args', default=2, type=int,
     help='Number of command arguments')
 parser.add_argument('--output',
@@ -278,7 +282,7 @@ title = [
 col = 0
 for item in (title):
     worksheet.write(5, col, item, t9b_l_i_box)
-    for row in range(6,26):
+    for row in range(6,args.num_alarms):
         worksheet.write(row, col, "", t9_box)
     col += 1
 
@@ -294,7 +298,7 @@ for num in range(0,args.alarm_rvs):
     for item in (return_value):
         worksheet.write(5, col, item, t9b_l_i_box)
         worksheet.set_column(col, col, 10.13)
-        for row in range(6,26):
+        for row in range(6,args.num_alarms):
             worksheet.write(row, col, "", t9_box)
         col += 1
 
@@ -336,7 +340,7 @@ title = [
 col = 0
 for item in (title):
     worksheet.write(5, col, item, t9b_l_i_box)
-    for row in range(6,52):
+    for row in range(6,args.num_statuses):
         worksheet.write(row, col, "", t9_box)
     col += 1
 
@@ -352,7 +356,7 @@ for num in range(0,args.status_rvs):
     for item in (return_value):
         worksheet.write(5, col, item, t9b_l_i_box)
         worksheet.set_column(col, col, 10.13)
-        for row in range(6,52):
+        for row in range(6,args.num_statuses):
             worksheet.write(row, col, "", t9_box)
         col += 1
 

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -155,7 +155,11 @@ usage = "Usage: xlsx2yaml.rb [options] [XLSX]"
 OptionParser.new do |opts|
   opts.banner = usage
 
-  opts.on("-s", "--site", "Include site") do |s|
+  opts.on("-o", "--object", "Output object information") do |o|
+    options[:object] = o
+  end
+
+  opts.on("-s", "--site", "Output site information") do |s|
     options[:site] = s
   end
 
@@ -521,5 +525,9 @@ workbook.each do |sheet|
 end
 
 sxl["sites"] = sites if options[:site]
+
+# Clear "objects" if site should be used
+sxl.delete("objects") if options[:site]
+
 reindent(sxl.to_yaml)
 

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -138,22 +138,20 @@ end
 # signal_type: "alarms", "statuses" or "commands"
 # signal_code: alarmCodeId, statusCodeId or commandCodeId
 def add_object(object_type, signal_type, signal_code, value)
-  if value != nil
-    object = { 'object' => value }
-    signal = { signal_code => object }
-    if @site_yaml['objects']
-      if @site_yaml['objects'][object_type]
-        if @site_yaml['objects'][object_type][signal_type]
-          @site_yaml['objects'][object_type][signal_type][signal_code] = object
-        else
-          @site_yaml['objects'][object_type][signal_type] = { signal_code =>  object }
-        end
+  object = { 'object' => value }
+  signal = { signal_code => object }
+  if @site_yaml['objects']
+    if @site_yaml['objects'][object_type]
+      if @site_yaml['objects'][object_type][signal_type]
+        @site_yaml['objects'][object_type][signal_type][signal_code] = object
       else
-        @site_yaml['objects'][object_type] = { signal_type => { signal_code => object } }
+        @site_yaml['objects'][object_type][signal_type] = { signal_code =>  object }
       end
     else
-      @site_yaml['objects'] = { object_type => { signal_type => { signal_code => object } } }
+      @site_yaml['objects'][object_type] = { signal_type => { signal_code => object } }
     end
+  else
+    @site_yaml['objects'] = { object_type => { signal_type => { signal_code => object } } }
   end
 end
 
@@ -325,7 +323,10 @@ workbook.each do |sheet|
       # Add alarm to the sxl structure
       add_signal(sxl["objects"], a[0], "alarms", a[2], alarm)
 
-      # Add the optional field 'object'?
+      # Add the optional field 'object' to the site structure
+      if a[1] and !a[1].empty?
+        add_object(a[0], "statuses",  a[2], a[1])
+      end
 
       y = y + 1
     end
@@ -434,7 +435,7 @@ workbook.each do |sheet|
       add_signal(sxl["objects"], s[0], "statuses", s[2], status)
 
       # Add the optional field 'object' to the site structure
-      if s[1]
+      if s[1] and !s[1].empty?
         add_object(s[0], "statuses",  s[2], s[1])
       end
 
@@ -507,7 +508,9 @@ workbook.each do |sheet|
         add_signal(sxl["objects"], c[0], "commands", c[2], command)
 
         # Add the optional field 'object' to the site structure
-        add_object(c[0], "commands",  c[2], c[1])
+        if c[1] and !c[1].empty?
+          add_object(c[0], "commands",  c[2], c[1])
+        end
 
         y = y + 1
       end

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -113,11 +113,21 @@ def add_signal(dest, object_type, signal_type, signal_code, body)
     if dest[object_type][signal_type]
       dest[object_type][signal_type][signal_code] = body
     else
-      alarms = { signal_code => body }
-      dest[object_type][signal_type] = body
+      signals = { signal_code => body }
+      dest[object_type][signal_type] = signals
     end
   else
     STDERR.puts "Object #{signal_code} not found"
+  end
+end
+
+# add individual value to a return value
+def add_rv_value(dest, value, description)
+  v = to_integer(value)
+  if dest['values']
+    dest['values'][v.to_s] = description
+  else
+    dest['values'] = {v.to_s => description}
   end
 end
 
@@ -254,13 +264,8 @@ workbook.each do |sheet|
                 desc = ''
               end
 
-              # Add to yaml
-              v = to_integer(v)
-              if rv[sheet[y][x].value]['values']
-                rv[sheet[y][x].value]['values'][v] = desc
-              else
-                rv[sheet[y][x].value]['values'] = {v => desc}
-              end
+              # Add value to return value
+              add_rv_value(rv[sheet[y][x].value], v, desc)
             }
           else
             # Set 'max' and 'min' if type is integer, long or real
@@ -376,13 +381,8 @@ workbook.each do |sheet|
                 desc = ''
               end
 
-              # Add to yaml
-              v = to_integer(v)
-              if a[sheet[y][x].value]['values']
-                a[sheet[y][x].value]['values'][v] = desc
-              else
-                a[sheet[y][x].value]['values'] = {v => desc}
-              end
+              # Add value to return value
+              add_rv_value(a[sheet[y][x].value], v, desc)
             }
           else
             # Set 'max' and 'min' if type is integer, long or real
@@ -409,7 +409,7 @@ workbook.each do |sheet|
       status.store("object", s[1]) if s[1] != nil
 
       # Add status to the yaml structure
-      add_signal(sxl["objects"], s[0], "statuses", a[2], status)
+      add_signal(sxl["objects"], s[0], "statuses", s[2], status)
 
       y = y + 1
     end
@@ -449,13 +449,8 @@ workbook.each do |sheet|
                   desc = ''
                 end
 
-                # Add to yaml
-                v = to_integer(v)
-                if a[sheet[y][x].value]['values']
-                  a[sheet[y][x].value]['values'][v.to_s] = desc
-                else
-                  a[sheet[y][x].value]['values'] = {v.to_s => desc}
-                end
+                # Add value to return value
+                add_rv_value(a[sheet[y][x].value], v, desc)
               }
             else
               # Set 'max' and 'min' if type is integer, long or real

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -67,22 +67,14 @@ def get_object_section(sheet, type, options)
       if object[2] == nil
         objects[key] = { 'description' => object[1] }
       else
-        if options[:extended]
-          objects[key] = { object[1] => { 'componentId' => object[2], 'ntsObjectId' => object[3] } }
-          objects[key][object[1]].store("externalNtsId", to_integer(object[4])) if object[4] != nil
-          objects[key][object[1]].store("description", object[5]) if object[5] != nil
-        else
-          objects[key] = { object[1] => object[2] }
-        end
+        objects[key] = { object[1] => { 'componentId' => object[2], 'ntsObjectId' => object[3] } }
+        objects[key][object[1]].store("externalNtsId", to_integer(object[4])) if object[4] != nil
+        objects[key][object[1]].store("description", object[5]) if object[5] != nil
       end
     else
-        if options[:extended]
-          newobject = { object[1] => { 'componentId' => object[2], 'ntsObjectId' => object[3] } }
-          newobject[object[1]].store("externalNtsId", to_integer(object[4])) if object[4] != nil
-          newobject[object[1]].store("description", object[5]) if object[5] != nil
-        else
-          newobject = { object[1] => object[2] }
-        end
+        newobject = { object[1] => { 'componentId' => object[2], 'ntsObjectId' => object[3] } }
+        newobject[object[1]].store("externalNtsId", to_integer(object[4])) if object[4] != nil
+        newobject[object[1]].store("description", object[5]) if object[5] != nil
       objects[key] = objects[key].merge(newobject)
     end
     y = y + 1
@@ -167,9 +159,6 @@ OptionParser.new do |opts|
     options[:site] = s
   end
 
-  opts.on("-e", "--extended", "Extended fields") do |e|
-    options[:extended] = e
-  end
 end.parse!
 
 if ARGV.length < 1
@@ -191,13 +180,11 @@ workbook.each do |sheet|
       sxl["version"] = sheet[20][1].value
       sxl["date"] = sheet[20][2].value
       sxl["description"] = sheet[5][1].value
-      if options[:extended]
-        sxl["constructor"] = sheet[9][1].value if sheet[9]
-        sxl["reviewed"] = sheet[11][1].value if sheet[11][1].value
-        sxl["approved"] = sheet[13][1].value if sheet[13] and sheet[13][1]
-        sxl["created-date"] = sheet[17][1].value if sheet[17]
-        sxl["rsmp-version"] = sheet[25][1].value if sheet[25]
-      end
+      sxl["constructor"] = sheet[9][1].value if sheet[9]
+      sxl["reviewed"] = sheet[11][1].value if sheet[11][1].value
+      sxl["approved"] = sheet[13][1].value if sheet[13] and sheet[13][1]
+      sxl["created-date"] = sheet[17][1].value if sheet[17]
+      sxl["rsmp-version"] = sheet[25][1].value if sheet[25]
     end
   when "Object types"
     # grouped objects
@@ -259,9 +246,7 @@ workbook.each do |sheet|
               rv[sheet[y][x].value]['min'] = values[0].to_i
               rv[sheet[y][x].value]['max'] = values[1].to_i
             else
-              if options[:extended]
-                rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
-              end
+              rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
           end
         end
@@ -279,11 +264,9 @@ workbook.each do |sheet|
         'priority' => a[6],
         'category' => a[7]
       }
-      if options[:extended]
-        alarm.store("object", a[1]) if a[1] != nil
-        alarm.store("externalAlarmCodeId", a[4]) if a[4] != nil
-        alarm.store("externalNtsAlarmCodeId", to_integer(a[5])) if a[5] != nil
-      end
+      alarm.store("object", a[1]) if a[1] != nil
+      alarm.store("externalAlarmCodeId", a[4]) if a[4] != nil
+      alarm.store("externalNtsAlarmCodeId", to_integer(a[5])) if a[5] != nil
 
       if !rv.empty?
         alarm['arguments'] = rv
@@ -332,11 +315,9 @@ workbook.each do |sheet|
         STDERR.puts "Object #{agg[0]} not found"
       end
 
-      if options[:extended]
-        sxl["objects"][agg[0]]["functional_position"] = agg[2]
-        sxl["objects"][agg[0]]["functional_state"] = agg[3]
-        sxl["objects"][agg[0]]["aggregated_status_description"] = agg[4]
-      end
+      sxl["objects"][agg[0]]["functional_position"] = agg[2]
+      sxl["objects"][agg[0]]["functional_state"] = agg[3]
+      sxl["objects"][agg[0]]["aggregated_status_description"] = agg[4]
       
       y = y + 1
 
@@ -394,9 +375,7 @@ workbook.each do |sheet|
               a[sheet[y][x].value]['max'] = values[1].to_i
               a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
             else
-              if options[:extended]
-                a[sheet[y][x].value]['range'] = sheet[y][x+2].value
-              end
+              a[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
           end
         end
@@ -412,9 +391,7 @@ workbook.each do |sheet|
         'description' => s[3],
         'arguments' => a
       }
-      if options[:extended]
-        status.store("object", s[1]) if s[1] != nil
-      end
+      status.store("object", s[1]) if s[1] != nil
 
       # Add to yaml
       if sxl["objects"][s[0]]
@@ -482,9 +459,7 @@ workbook.each do |sheet|
                 a[sheet[y][x].value]['max'] = values[1].to_i
                 a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
               else
-                if options[:extended]
-                  a[sheet[y][x].value]['range'] = sheet[y][x+3].value
-                end
+                a[sheet[y][x].value]['range'] = sheet[y][x+3].value
               end
             end
           end
@@ -504,9 +479,7 @@ workbook.each do |sheet|
           'arguments' => a,
           'command' => co
         }
-        if options[:extended]
-          command.store("object", c[1]) if c[1] != nil
-        end
+        command.store("object", c[1]) if c[1] != nil
 
         # Add to yaml
         if sxl["objects"][c[0]]

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -249,8 +249,6 @@ workbook.each do |sheet|
               values = sheet[y][x+2].value.tr('[]','').split("-")
               rv[sheet[y][x].value]['min'] = values[0].to_i
               rv[sheet[y][x].value]['max'] = values[1].to_i
-            else
-              rv[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
           end
         end
@@ -378,8 +376,6 @@ workbook.each do |sheet|
               a[sheet[y][x].value]['min'] = values[0].to_i
               a[sheet[y][x].value]['max'] = values[1].to_i
               a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
-            else
-              a[sheet[y][x].value]['range'] = sheet[y][x+2].value
             end
           end
         end
@@ -462,8 +458,6 @@ workbook.each do |sheet|
                 a[sheet[y][x].value]['min'] = values[0].to_i
                 a[sheet[y][x].value]['max'] = values[1].to_i
                 a[sheet[y][x].value]['type'] << "_list"	# Add _list to type if min/max is used
-              else
-                a[sheet[y][x].value]['range'] = sheet[y][x+3].value
               end
             end
           end

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -124,6 +124,8 @@ end
 # add individual value to a return value
 def add_rv_value(dest, value, description)
   v = to_integer(value)
+  description = '' if description.nil?
+
   if dest['values']
     dest['values'][v.to_s] = description
   else
@@ -260,9 +262,6 @@ workbook.each do |sheet|
               # the description field using "key: value" format
               # Removes the key in description on match
               desc = get_value(rv[sheet[y][x].value]['description'], v)
-              if desc.nil? then
-                desc = ''
-              end
 
               # Add value to return value
               add_rv_value(rv[sheet[y][x].value], v, desc)
@@ -377,9 +376,6 @@ workbook.each do |sheet|
               # Try to find the corresponding description in
               # the description field using "key: value" format
               desc = get_value(a[sheet[y][x].value]['description'], v)
-              if desc.nil? then
-                desc = ''
-              end
 
               # Add value to return value
               add_rv_value(a[sheet[y][x].value], v, desc)
@@ -445,9 +441,6 @@ workbook.each do |sheet|
                 # the description field using "key: value" format
                 # Removes the key in description on match
                 desc = get_value(a[sheet[y][x].value]['description'], v)
-                if desc.nil? then
-                  desc = ''
-                end
 
                 # Add value to return value
                 add_rv_value(a[sheet[y][x].value], v, desc)

--- a/xlsx2yaml.rb
+++ b/xlsx2yaml.rb
@@ -381,8 +381,9 @@ workbook.each do |sheet|
       a = {}
       while(sheet[y][x] != nil and sheet[y][x].value != nil and !sheet[y][x].value.empty?) do
 
-        if sheet[y][x+3].value.empty?
+        if sheet[y][x+3] == nil or sheet[y][x+3].value == nil or sheet[y][x+3].value.empty?
           STDERR.puts "Error: comment field for " + sheet[y][x].value + " in " + s[0] + " " + s[2] + " is empty"
+          exit 1
         end
 
         a[sheet[y][x].value] = {

--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -229,6 +229,10 @@ def print_alarms():
                             else:
                                 if type == "boolean":
                                     value = "-True |br|\n-False"
+                                elif type == "string":
+                                    value = "[string]"
+                                elif type == "base64":
+                                    value = "[base64]"
                                 elif type == "integer" or type == "long" or type == "float":
                                     if "min" in argument:
                                         min = argument['min']
@@ -337,6 +341,10 @@ def print_status():
                             else:
                                 if type == "boolean":
                                     value = "-False |br|\n-True"
+                                elif type == "string":
+                                    value = "[string]"
+                                elif type == "base64":
+                                    value = "[base64]"
                                 elif type == "integer" or type == "long" or type == "float":
                                     if "min" in argument:
                                         min = argument['min']
@@ -433,8 +441,12 @@ def print_commands():
                                     val_list.append("-" + v)
                                 value = " |br|\n".join(val_list)
                             else:
-                                if(type == "boolean"):
+                                if type == "boolean":
                                     value = "-False |br|\n-True"
+                                elif type == "string":
+                                    value = "[string]"
+                                elif type == "base64":
+                                    value = "[base64]"
                                 elif type == "integer":
                                     if "min" in argument:
                                         min = argument['min']

--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -240,11 +240,7 @@ def print_alarms():
                                         max = ""
                                     value = "[" + str(min) + "-" + str(max) + "]"
                                 else:
-                                    # Extended
-                                    if "range" in argument:
-                                        value = argument['range']
-                                    else:
-                                        value = ""
+                                    value = ""
                             if "description" in argument:
                                 comment = argument['description'].replace("\n", " |br|\n")
 
@@ -352,11 +348,7 @@ def print_status():
                                         max = ""
                                     value = "[" + str(min) + "-" + str(max) + "]"
                                 else:
-                                    # Extended
-                                    if "range" in argument:
-                                        value = argument['range']
-                                    else:
-                                        value = ""
+                                    value = ""
                             if "description" in argument:
                                 comment = argument['description'].rstrip("\n")
                                 comment = comment.replace("\n", " |br|\n")
@@ -454,11 +446,7 @@ def print_commands():
                                         max = ""
                                     value = "[" + str(min) + "-" + str(max) + "]"
                                 else:
-                                    # Extended
-                                    if "range" in argument:
-                                        value = argument['range']
-                                    else:
-                                        value = ""
+                                    value = ""
                             if "description" in argument:
                                 comment = argument['description'].rstrip("\n")
                                 comment = comment.replace("\n", " |br|\n")

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -200,16 +200,14 @@ sxl["objects"].each { |object|
                 description += + v.to_s + ": " + desc + "\n"
               end
             }
+          elsif value["type"] == "string"
+            values = "[string]"
           elsif not value["min"].nil?
             min = value["min"]
             max = value["max"]
             values = "[" + min.to_s + "-" + max.to_s + "]"
           else
-            if value["type"] == "string"
-              values = "[string]"
-            else # unknown type
-              values = ""
-            end
+            values = ""
           end
           values.chomp!
           description.chomp!
@@ -257,9 +255,6 @@ sxl["objects"].each { |object|
       if value["type"] == "boolean"
           values = "-False\n-True"
           set_cell(sheet, col+2, row, values)
-      elsif value["type"] == "string"
-          values = "[string]"
-          set_cell(sheet, col+2, row, values)
       elsif value["type"] == "base64"
           values = "[base64]"
           set_cell(sheet, col+2, row, values)
@@ -274,6 +269,8 @@ sxl["objects"].each { |object|
               description += + v.to_s + ": " + desc + "\n"
             end
           }
+        elsif value["type"] == "string"
+          values = "[string]"
         elsif not value["min"].nil?
           min = value["min"]
           max = value["max"]
@@ -328,9 +325,6 @@ sxl["objects"].each { |object|
       if value["type"] == "boolean"
           values = "-False\n-True"
           set_cell(sheet, col+3, row, values)
-      elsif value["type"] == "string"
-          values = "[string]"
-          set_cell(sheet, col+3, row, values)
       elsif value["type"] == "base64"
           values = "[base64]"
           set_cell(sheet, col+3, row, values)
@@ -345,6 +339,8 @@ sxl["objects"].each { |object|
               description += + v.to_s + ": " + desc + "\n"
             end
           }
+        elsif value["type"] == "string"
+          values = "[string]"
         elsif not value["min"].nil?
           min = value["min"]
           max = value["max"]

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -35,12 +35,20 @@ def find_row(sheet, string)
 end
 
 options = {}
-usage = "Usage: yaml2xlsx.rb [--template <XLSX>]"
+usage = "Usage: yaml2xlsx.rb [OPTIONS]--template <XLSX>] [sxl.yaml] [site.yaml]"
 OptionParser.new do |opts|
   opts.banner = usage
 
   opts.on("--template [XLSX]", "SXL Template") do |p|
     options[:template] = p
+  end
+
+  opts.on("--sxl [YAML]", "Signal Exchange List (objects)") do |x|
+    options[:sxl] = x
+  end
+
+  opts.on("--site [YAML]", "Signal Exchange List (site)") do |t|
+    options[:site] = t
   end
 
   opts.on("--short-desc", "Short description") do |s|
@@ -53,25 +61,26 @@ OptionParser.new do |opts|
 end.parse!
 
 abort("--template needs to be set") if options[:template].nil?
-
+abort("--sxl needs to be set") if options[:sxl].nil?
+abort("--site needs to be set") if options[:site].nil?
 
 workbook = RubyXL::Parser.parse(options[:template])
 
-# Read yaml from stdin
-input = ARGF.read()
-sxl = YAML.load(input)
+# Read yaml
+sxl = YAML.load_file(options[:sxl])
+site = YAML.load_file(options[:site])
 
 # Version
 sheet = workbook['Version']
-set_cell(sheet, 2, 4, sxl["id"])            # Plant id
-set_cell(sheet, 2, 6, sxl["description"])   # Plant name
-set_cell(sheet, 2, 10, sxl["constructor"])  # Constructor
-set_cell(sheet, 2, 12, sxl["reviewed"])     # Reviewed
-set_cell(sheet, 2, 15, sxl["approved"])     # Approved
-set_cell(sheet, 2, 18, sxl["created-date"]) # Created date
-set_cell(sheet, 2, 21, sxl["version"])      # SXL revision number
-set_cell(sheet, 3, 21, sxl["date"])         # SXL revision date
-set_cell(sheet, 2, 26, sxl["rsmp-version"]) # RSMP version
+set_cell(sheet, 2, 4, site["id"])            # Plant id
+set_cell(sheet, 2, 6, site["description"])   # Plant name
+set_cell(sheet, 2, 10, site["constructor"])  # Constructor
+set_cell(sheet, 2, 12, site["reviewed"])     # Reviewed
+set_cell(sheet, 2, 15, site["approved"])     # Approved
+set_cell(sheet, 2, 18, site["created-date"]) # Created date
+set_cell(sheet, 2, 21, site["version"])      # SXL revision number
+set_cell(sheet, 3, 21, site["date"])         # SXL revision date
+set_cell(sheet, 2, 26, site["rsmp-version"]) # RSMP version
 
 # Object types
 sheet = workbook['Object types']
@@ -94,7 +103,7 @@ sxl["objects"].each { |object|
 sheet = workbook['Objects']
 gy = find_row(sheet, "Grouped objects")+3
 sy = find_row(sheet, "Single objects")+3
-sxl["sites"].each { |site|
+site["sites"].each { |site|
   set_cell(sheet, 2, 2, site[0])
   set_cell(sheet, 3, 2, site[1]["description"])
 

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -186,6 +186,12 @@ sxl["objects"].each { |object|
         if value["type"] == "boolean"
             values = "-False\n-True"
             set_cell(sheet, col+2, row, values)
+        elsif value["type"] == "string"
+            values = "[string]"
+            set_cell(sheet, col+2, row, values)
+        elsif value["type"] == "base64"
+            values = "[base64]"
+            set_cell(sheet, col+2, row, values)
         else
           description = ""
           if not value["values"].nil?
@@ -249,6 +255,12 @@ sxl["objects"].each { |object|
       set_cell(sheet, col+1, row, value["type"])
       if value["type"] == "boolean"
           values = "-False\n-True"
+          set_cell(sheet, col+2, row, values)
+      elsif value["type"] == "string"
+          values = "[string]"
+          set_cell(sheet, col+2, row, values)
+      elsif value["type"] == "base64"
+          values = "[base64]"
           set_cell(sheet, col+2, row, values)
       else
         description = ""
@@ -314,6 +326,12 @@ sxl["objects"].each { |object|
       set_cell(sheet, col+2, row, value["type"])
       if value["type"] == "boolean"
           values = "-False\n-True"
+          set_cell(sheet, col+3, row, values)
+      elsif value["type"] == "string"
+          values = "[string]"
+          set_cell(sheet, col+3, row, values)
+      elsif value["type"] == "base64"
+          values = "[base64]"
           set_cell(sheet, col+3, row, values)
       else
         description = ""

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -39,12 +39,12 @@ usage = "Usage: yaml2xlsx.rb [OPTIONS]--template <XLSX>] [sxl.yaml] [site.yaml]"
 OptionParser.new do |opts|
   opts.banner = usage
 
-  opts.on("--template [XLSX]", "SXL Template") do |p|
+  opts.on("--template [XLSX]", "Excel SXL Template") do |p|
     options[:template] = p
   end
 
-  opts.on("--sxl [YAML]", "Signal Exchange List (objects)") do |x|
-    options[:sxl] = x
+  opts.on("--objects [YAML]", "Signal Exchange List (objects)") do |x|
+    options[:objects] = x
   end
 
   opts.on("--site [YAML]", "Signal Exchange List (site)") do |t|
@@ -61,13 +61,13 @@ OptionParser.new do |opts|
 end.parse!
 
 abort("--template needs to be set") if options[:template].nil?
-abort("--sxl needs to be set") if options[:sxl].nil?
+abort("--objects needs to be set") if options[:objects].nil?
 abort("--site needs to be set") if options[:site].nil?
 
 workbook = RubyXL::Parser.parse(options[:template])
 
 # Read yaml
-sxl = YAML.load_file(options[:sxl])
+sxl = YAML.load_file(options[:objects])
 site = YAML.load_file(options[:site])
 
 # Version

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -187,35 +187,30 @@ sxl["objects"].each { |object|
             values = "-False\n-True"
             set_cell(sheet, col+2, row, values)
         else
-          # If 'range' exists, just use it
-          unless value["range"].nil?
-            set_cell(sheet, col+2, row, value["range"])
-          else
-            description = ""
-            if not value["values"].nil?
-              # Make a list of values and append to description
-              values = ""
-              value["values"].each { |v, desc |
-                values += "-" + v.to_s + "\n"
-                unless desc.empty?
-                  description += + v.to_s + ": " + desc + "\n"
-                end
-              }
-            elsif not value["min"].nil?
-              min = value["min"]
-              max = value["max"]
-              values = "[" + min.to_s + "-" + max.to_s + "]"
-            end
-            values.chomp!
-            description.chomp!
-            if value["description"].nil?
-              value["description"] = description
-            else
-              value["description"].concat("\n" + description)
-              value["description"].chomp!
-            end
-            set_cell(sheet, col+2, row, values)
+          description = ""
+          if not value["values"].nil?
+            # Make a list of values and append to description
+            values = ""
+            value["values"].each { |v, desc |
+              values += "-" + v.to_s + "\n"
+              unless desc.empty?
+                description += + v.to_s + ": " + desc + "\n"
+              end
+            }
+          elsif not value["min"].nil?
+            min = value["min"]
+            max = value["max"]
+            values = "[" + min.to_s + "-" + max.to_s + "]"
           end
+          values.chomp!
+          description.chomp!
+          if value["description"].nil?
+            value["description"] = description
+          else
+            value["description"].concat("\n" + description)
+            value["description"].chomp!
+          end
+          set_cell(sheet, col+2, row, values)
         end
         set_cell(sheet, col+3, row, value["description"])
         col += 4
@@ -254,34 +249,29 @@ sxl["objects"].each { |object|
           values = "-False\n-True"
           set_cell(sheet, col+2, row, values)
       else
-        # If 'range' exists, just use it
-        unless value["range"].nil?
-          set_cell(sheet, col+2, row, value["range"])
-        else
-          description = ""
-          if not value["values"].nil?
-            # Make a list of values and append to description
-            values = ""
-            value["values"].each { |v, desc |
-              values += "-" + v.to_s + "\n"
-              unless desc.empty?
-                description += + v.to_s + ": " + desc + "\n"
-              end
-            }
-          elsif not value["min"].nil?
-            min = value["min"]
-            max = value["max"]
-            values = "[" + min.to_s + "-" + max.to_s + "]"
-          end
-          values.chomp!
-          description.chomp!
-          if value["description"].nil?
-            value["description"] = description
-          else
-            value["description"].concat("\n" + description)
-          end
-          set_cell(sheet, col+2, row, values)
+        description = ""
+        if not value["values"].nil?
+          # Make a list of values and append to description
+          values = ""
+          value["values"].each { |v, desc |
+            values += "-" + v.to_s + "\n"
+            unless desc.empty?
+              description += + v.to_s + ": " + desc + "\n"
+            end
+          }
+        elsif not value["min"].nil?
+          min = value["min"]
+          max = value["max"]
+          values = "[" + min.to_s + "-" + max.to_s + "]"
         end
+        values.chomp!
+        description.chomp!
+        if value["description"].nil?
+          value["description"] = description
+        else
+          value["description"].concat("\n" + description)
+        end
+        set_cell(sheet, col+2, row, values)
       end
       set_cell(sheet, col+3, row, value["description"])
       col += 4
@@ -322,34 +312,29 @@ sxl["objects"].each { |object|
           values = "-False\n-True"
           set_cell(sheet, col+3, row, values)
       else
-        # If 'range' exists, just use it
-        unless value["range"].nil?
-          set_cell(sheet, col+3, row, value["range"])
-        else
-          description = ""
-          if not value["values"].nil?
-            # Make a list of values and append to description
-            values = ""
-            value["values"].each { |v, desc |
-              values += "-" + v.to_s + "\n"
-              unless desc.empty?
-                description += + v.to_s + ": " + desc + "\n"
-              end
-            }
-          elsif not value["min"].nil?
-            min = value["min"]
-            max = value["max"]
-            values = "[" + min.to_s + "-" + max.to_s + "]"
-          end
-          values.chomp!
-          description.chomp!
-          if value["description"].nil?
-            value["description"] = description
-          else
-            value["description"].concat("\n" + description)
-          end
-          set_cell(sheet, col+3, row, values)
+        description = ""
+        if not value["values"].nil?
+          # Make a list of values and append to description
+          values = ""
+          value["values"].each { |v, desc |
+            values += "-" + v.to_s + "\n"
+            unless desc.empty?
+              description += + v.to_s + ": " + desc + "\n"
+            end
+          }
+        elsif not value["min"].nil?
+          min = value["min"]
+          max = value["max"]
+          values = "[" + min.to_s + "-" + max.to_s + "]"
         end
+        values.chomp!
+        description.chomp!
+        if value["description"].nil?
+          value["description"] = description
+        else
+          value["description"].concat("\n" + description)
+        end
+        set_cell(sheet, col+3, row, values)
       end
       set_cell(sheet, col+4, row, value["description"])
       col += 5

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -201,6 +201,8 @@ sxl["objects"].each { |object|
             min = value["min"]
             max = value["max"]
             values = "[" + min.to_s + "-" + max.to_s + "]"
+          else
+            values = ""
           end
           values.chomp!
           description.chomp!
@@ -263,6 +265,8 @@ sxl["objects"].each { |object|
           min = value["min"]
           max = value["max"]
           values = "[" + min.to_s + "-" + max.to_s + "]"
+        else
+          values = ""
         end
         values.chomp!
         description.chomp!
@@ -326,6 +330,8 @@ sxl["objects"].each { |object|
           min = value["min"]
           max = value["max"]
           values = "[" + min.to_s + "-" + max.to_s + "]"
+        else
+          values = ""
         end
         values.chomp!
         description.chomp!

--- a/yaml2xlsx.rb
+++ b/yaml2xlsx.rb
@@ -186,9 +186,6 @@ sxl["objects"].each { |object|
         if value["type"] == "boolean"
             values = "-False\n-True"
             set_cell(sheet, col+2, row, values)
-        elsif value["type"] == "string"
-            values = "[string]"
-            set_cell(sheet, col+2, row, values)
         elsif value["type"] == "base64"
             values = "[base64]"
             set_cell(sheet, col+2, row, values)
@@ -208,7 +205,11 @@ sxl["objects"].each { |object|
             max = value["max"]
             values = "[" + min.to_s + "-" + max.to_s + "]"
           else
-            values = ""
+            if value["type"] == "string"
+              values = "[string]"
+            else # unknown type
+              values = ""
+            end
           end
           values.chomp!
           description.chomp!


### PR DESCRIPTION
- [x] Include extended information by default
- [x] xlsx2yaml.rb: Add options to output either object data (sxl) or site data in yaml format
- [x] yaml2xlsx.rb: Add options to use both sxl and site yaml files
- [x] xlsx2yaml.rb: Fix issue #5
- [x] xlsx2yaml.rb: 'object' field should be included in the site data (the tlc sxl doesn't use this)
- [x] xlsx2yaml.rb: Investigate issues with site output 
- [x] xlsx2yaml.rb: Include metadata
- [ ] consider making a tool for merging the yaml files for use with the RSMP simulator
- [x] investigate differences in excel and yaml sources
- [x] update readme
