### PR TITLE
Add merge_yaml.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Exports signal exchange lists (SXL) used by RSMP from Excel-format (xlsx) to
 various formats.
 
 * **create_template.py** - Creates SXL template in Excel format
+* **merge_yaml.rb** - Merge object and site YAML files
 * **xlsx2csv.rb**  - Reads SXL in Excel format and outputs to CSV format
 * **xlsx2yaml.rb** - Reads SXL in Excel format and outputs to YAML format
 * **yaml2xlsx.rb** - Reads SXL in YAML format and outputs to Excel format
@@ -15,6 +16,10 @@ Notes about create_template.py
 * Requires: pip3 install xlsxwriter --user (or apt install python3-xlsxwriter)
 * Usage: create_template.py [OPTIONS]
 * See create_template.py -h for available options
+
+Notes about merge_yaml.rb
+-------------------------
+Merge object and site yaml files for use with the RSMP simulator
 
 Notes about xlsx2csv
 --------------------

--- a/merge_yaml.rb
+++ b/merge_yaml.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+require 'yaml'
+require 'optparse'
+
+# Re-indent code due to ruby yaml output fails to indent multiline text
+# properly when blank lines occurs in the middle of text
+def reindent(text)
+  prev_line = ""
+  indent = ""
+  text.each_line do |line|
+    if line == "\n"
+      # Check white spaces in the beginning of previous line
+      indent = prev_line.match(/^([ ]+)/)[0] rescue false
+      line = indent + "\n"
+    end
+    print line
+    prev_line = line
+  end
+end
+
+options = {}
+usage = "Usage: mergeyaml.rb --objects [objects.yaml] --site [site.yaml]"
+OptionParser.new do |opts|
+  opts.banner = usage
+
+  opts.on("--objects [YAML]", "Signal Exchange List (objects)") do |x|
+    options[:objects] = x
+  end
+
+  opts.on("--site [YAML]", "Signal Exchange List (site)") do |t|
+    options[:site] = t
+  end
+end.parse!
+
+abort("--objects needs to be set") if options[:objects].nil?
+abort("--site needs to be set") if options[:site].nil?
+
+# Read yaml
+objects = YAML.load_file(options[:objects])
+site = YAML.load_file(options[:site])
+
+# Merge
+objects["sites"] = site["sites"]
+
+reindent(objects.to_yaml)


### PR DESCRIPTION
Add merge_yaml.rb for merging object and site YAML files

A SXL in YAML format is used by rsmp_schema. It contains the signals, e.g. alarms, commands, statuses. But the RSMP simulator uses a YAML file with not only the signals but also the components. This tool merges a YAML file from the rsmp_schema with a YAML file containing the components (sites) for use with the RSMP simulator
