### PR TITLE
xlsx2csv: Don't zip compress

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Notes about xlsx2csv
 
 * Requires: gem install rubyXL
 * Usage: xlsx2csv [XLSX]
-* Exports SXL from XLSX format to CSV files, zip compressed.
-  Suitable for use with the RSMP simulators
+* Exports SXL from XLSX format to CSV files
+  Suitable for use with the RSMP simulator
 
 Notes about xlsx2yaml
 ---------------------

--- a/xlsx2csv.rb
+++ b/xlsx2csv.rb
@@ -7,7 +7,7 @@ require 'rubyXL/convenience_methods'
 xlsx = ARGV[0].dup
 workbook = RubyXL::Parser.parse(xlsx)
 
-system("mkdir Objects")
+Dir.mkdir("Objects")
 workbook.each do |sheet|
   oname = sheet.sheet_name.gsub(/ /, '_')
 
@@ -56,11 +56,3 @@ workbook.each do |sheet|
     end
   end
 end
-
-system("zip -q -j Objects.zip Objects/*")
-system("rm -rf Objects")
-
-# Rename after source file
-xlsx.gsub!(/ /, '_')
-xlsx.gsub!(/.xlsx/, '')
-system("mv Objects.zip " + xlsx + ".zip")


### PR DESCRIPTION
In order to increase compatibility with Windows and reduce dependencies, don't zip compress the csv files and remove any system() calls.